### PR TITLE
Canary for &foo->bar when foo is NULL

### DIFF
--- a/addr-null/README
+++ b/addr-null/README
@@ -1,0 +1,2 @@
+The expectation is that taking &foo->bar is safe and can be used as a
+replacement for offsetof even when foo is NULL.

--- a/addr-null/p1.c
+++ b/addr-null/p1.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+
+struct s {
+    int a;
+};
+
+int main(int argc, char** argv)
+{
+    static struct s* f;
+    if (&(f->a)) {
+        printf("f is not NULL\n");
+    }
+    if (!&(f->a)) {
+        printf("f is NULL\n");
+    }
+    return 0;
+}

--- a/addr-null/p1.output
+++ b/addr-null/p1.output
@@ -1,0 +1,1 @@
+f is NULL

--- a/addr-null/p2.c
+++ b/addr-null/p2.c
@@ -1,0 +1,30 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <limits.h>
+
+struct s {
+    uint8_t a;
+    uint8_t b;
+};
+
+static struct s* f;
+
+void foo(void)
+{
+    if (&(f->b) != 1) {
+        printf("f is not NULL\n");
+    }
+    if (&(f->b) == 1) {
+        printf("f is NULL\n");
+    }
+}
+
+int main(int argc, char** argv)
+{
+    if (argc == INT_MAX) {
+        static struct s a;
+        f = &a;
+    }
+    foo();
+    return 0;
+}

--- a/addr-null/p2.output
+++ b/addr-null/p2.output
@@ -1,0 +1,1 @@
+f is NULL


### PR DESCRIPTION
This is probably my "favorite" instance of UB. I tend to find programs doing this either as a replacement for offsetof (for whatever reason) or just because it's computing some addresses before determining whether the base is NULL or not. I haven't caught clang or gcc exploiting this one yet, but I wouldn't be surprised if it did.
